### PR TITLE
Add libsssh2_session_method_pref

### DIFF
--- a/ssh2/c_ssh2.pxd
+++ b/ssh2/c_ssh2.pxd
@@ -43,6 +43,18 @@ cdef extern from "libssh2.h" nogil:
         enum:
             LIBSSH2_HOSTKEY_HASH_SHA256
 
+    enum:
+        LIBSSH2_METHOD_KEX
+        LIBSSH2_METHOD_HOSTKEY
+        LIBSSH2_METHOD_CRYPT_CS
+        LIBSSH2_METHOD_CRYPT_SC
+        LIBSSH2_METHOD_MAC_CS
+        LIBSSH2_METHOD_MAC_SC
+        LIBSSH2_METHOD_COMP_CS
+        LIBSSH2_METHOD_COMP_SC
+        LIBSSH2_METHOD_LANG_CS
+        LIBSSH2_METHOD_LANG_SC
+
     # ctypedef libssh2_uint64_t libssh2_struct_stat_size
     ctypedef struct libssh2_struct_stat:
         dev_t   st_dev

--- a/ssh2/session.pyx
+++ b/ssh2/session.pyx
@@ -45,6 +45,17 @@ LIBSSH2_HOSTKEY_TYPE_UNKNOWN = c_ssh2.LIBSSH2_HOSTKEY_TYPE_UNKNOWN
 LIBSSH2_HOSTKEY_TYPE_RSA = c_ssh2.LIBSSH2_HOSTKEY_TYPE_RSA
 LIBSSH2_HOSTKEY_TYPE_DSS = c_ssh2.LIBSSH2_HOSTKEY_TYPE_DSS
 
+LIBSSH2_METHOD_KEX = c_ssh2.LIBSSH2_METHOD_KEX
+LIBSSH2_METHOD_HOSTKEY = c_ssh2.LIBSSH2_METHOD_HOSTKEY
+LIBSSH2_METHOD_CRYPT_CS = c_ssh2.LIBSSH2_METHOD_CRYPT_CS
+LIBSSH2_METHOD_CRYPT_SC = c_ssh2.LIBSSH2_METHOD_CRYPT_SC
+LIBSSH2_METHOD_MAC_CS = c_ssh2.LIBSSH2_METHOD_MAC_CS
+LIBSSH2_METHOD_MAC_SC = c_ssh2.LIBSSH2_METHOD_MAC_SC
+LIBSSH2_METHOD_COMP_CS = c_ssh2.LIBSSH2_METHOD_COMP_CS
+LIBSSH2_METHOD_COMP_SC = c_ssh2.LIBSSH2_METHOD_COMP_SC
+LIBSSH2_METHOD_LANG_CS = c_ssh2.LIBSSH2_METHOD_LANG_CS
+LIBSSH2_METHOD_LANG_SC = c_ssh2.LIBSSH2_METHOD_LANG_SC
+
 
 cdef class Session:
 
@@ -66,6 +77,15 @@ cdef class Session:
         cdef int rc
         with nogil:
             rc = c_ssh2.libssh2_session_disconnect(self._session, b"end")
+        return handle_error_codes(rc)
+
+    def method_pref(self, method_type, pref_methods):
+        cdef int rc
+        cdef int _method_type = int(method_type)
+        cdef bytes b_pref_methods = to_bytes(pref_methods)
+        cdef char *_pref_methods = b_pref_methods
+        with nogil:
+            rc = c_ssh2.libssh2_session_method_pref(self._session, _method_type, _pref_methods)
         return handle_error_codes(rc)
 
     def handshake(self, sock not None):


### PR DESCRIPTION
This enables giving ssh a prefered list of options such as
kex, ciphers, MACs and etc